### PR TITLE
Fix for flushed streams

### DIFF
--- a/src/generate-transaction-chunks-async.ts
+++ b/src/generate-transaction-chunks-async.ts
@@ -5,7 +5,7 @@ import {
   generateLeaves,
   generateProofs,
   MAX_CHUNK_SIZE,
-  MIN_CHUNK_SIZE,
+  MIN_CHUNK_SIZE
 } from 'arweave/node/lib/merkle';
 import Transaction from 'arweave/node/lib/transaction';
 import chunker from 'stream-chunker';
@@ -43,45 +43,55 @@ export function generateTransactionChunksAsync() {
       source,
       chunker(MAX_CHUNK_SIZE, { flush: true }),
       async function (chunkedSource: AsyncIterable<Buffer>) {
-        for await (const chunk of chunkedSource) {
-          if (expectChunkGenerationCompleted) {
-            throw Error('Expected chunk generation to have completed.');
-          }
-
-          if (chunk.byteLength >= MIN_CHUNK_SIZE && chunk.byteLength <= MAX_CHUNK_SIZE) {
-            await addChunk(chunkStreamByteIndex, chunk);
-          } else if (chunk.byteLength < MIN_CHUNK_SIZE) {
-            if (previousDataChunk) {
-              // If this final chunk is smaller than the minimum chunk size, rebalance this final chunk and
-              // the previous chunk to keep the final chunk size above the minimum threshold.
-              const remainingBytes = Buffer.concat(
-                [previousDataChunk, chunk],
-                previousDataChunk.byteLength + chunk.byteLength,
-              );
-              const rebalancedSizeForPreviousChunk = Math.ceil(remainingBytes.byteLength / 2);
-
-              const previousChunk = chunks.pop()!;
-              const rebalancedPreviousChunk = await addChunk(
-                previousChunk.minByteRange,
-                remainingBytes.slice(0, rebalancedSizeForPreviousChunk),
-              );
-
-              await addChunk(
-                rebalancedPreviousChunk.maxByteRange,
-                remainingBytes.slice(rebalancedSizeForPreviousChunk),
-              );
-            } else {
-              // This entire stream should be smaller than the minimum chunk size, just add the chunk in.
-              await addChunk(chunkStreamByteIndex, chunk);
+        for await (const volatileChunk of chunkedSource) {
+          async function processChunk(chunk: Buffer) {
+            if (expectChunkGenerationCompleted) {
+              throw Error('Expected chunk generation to have completed.');
             }
-
-            expectChunkGenerationCompleted = true;
-          } else if (chunk.byteLength > MAX_CHUNK_SIZE) {
-            throw Error('Encountered chunk larger than max chunk size.');
+  
+            if (chunk.byteLength >= MIN_CHUNK_SIZE && chunk.byteLength <= MAX_CHUNK_SIZE) {
+              await addChunk(chunkStreamByteIndex, chunk);
+            } else if (chunk.byteLength < MIN_CHUNK_SIZE) {
+              if (previousDataChunk) {
+                // If this final chunk is smaller than the minimum chunk size, rebalance this final chunk and
+                // the previous chunk to keep the final chunk size above the minimum threshold.
+                const remainingBytes = Buffer.concat(
+                  [previousDataChunk, chunk],
+                  previousDataChunk.byteLength + chunk.byteLength,
+                );
+                const rebalancedSizeForPreviousChunk = Math.ceil(remainingBytes.byteLength / 2);
+  
+                const previousChunk = chunks.pop()!;
+                const rebalancedPreviousChunk = await addChunk(
+                  previousChunk.minByteRange,
+                  remainingBytes.slice(0, rebalancedSizeForPreviousChunk),
+                );
+  
+                await addChunk(
+                  rebalancedPreviousChunk.maxByteRange,
+                  remainingBytes.slice(rebalancedSizeForPreviousChunk),
+                );
+              } else {
+                // This entire stream should be smaller than the minimum chunk size, just add the chunk in.
+                await addChunk(chunkStreamByteIndex, chunk);
+              }
+  
+              expectChunkGenerationCompleted = true;
+            } else if (chunk.byteLength > MAX_CHUNK_SIZE) {
+              // This can happen when the read stream is flushed
+              // In this case, process the head chunk and recurse through the tail
+              const chunkHead = chunk.slice(0, MAX_CHUNK_SIZE)
+              await processChunk(chunkHead);
+              const chunkTail = chunk.slice(MAX_CHUNK_SIZE)
+              await processChunk(chunkTail);
+              // The rest of the function should not be called for oversized chunks
+              return;
+            }
+  
+            chunkStreamByteIndex += chunk.byteLength;
+            previousDataChunk = chunk;
           }
-
-          chunkStreamByteIndex += chunk.byteLength;
-          previousDataChunk = chunk;
+          processChunk(volatileChunk);
         }
       },
     );


### PR DESCRIPTION
Fixes #2 

Problem: `chunker` from the 'stream-chunker' library does not always produce chunks smaller than `MAX_CHUNK_SIZE`. If the stream is flushed (as `S3` objects from `aws-sdk` seems to cause), then all remaining data is dumped into the next pipeline stage. AFAICT there is no way to get around this (I even tried forking `chunker`'s `flush` callback to push the data separately, but it seems to concatenate it anyway.

Solution: If `generateTransactionChunksAsync` or `uploadTransactionAsync` receive a chunk greater than `MAX_CHUNK_SIZE`, they split it themselves. I've implemented this by processing a `MAX_CHUNK_SIZE` chunk, then recursing through the tail. I believe this should be safe as the stack size will be limited limited to ~ buffer.byteLength / 256kB